### PR TITLE
Fix numba failure in systems where numpy asytpe(int) is int64

### DIFF
--- a/swtloc/abstractions.py
+++ b/swtloc/abstractions.py
@@ -371,7 +371,7 @@ class SWTImage(TextTransformBase):
         else:
             self.image_edged = edge_function(self.image_gaussian_blurred)
 
-        self.image_edged = (self.image_edged != 0).astype(int)
+        self.image_edged = (self.image_edged != 0).astype(np.int32)
 
     def _gradientImage(self):
         """


### PR DESCRIPTION
On systems where NumPy astype(int) uses int64, the following error occurs:

numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend) Cannot unify array(int64, 2d, C) and array(int32, 2d, C) for 'swt_matrix.2', defined at ../venv/lib/python3.10/site-packages/swtloc/core.py (126)

```
File "../venv/lib/python3.10/site-packages/swtloc/core.py", line 126:
def swt_strokes(edged_image,
    <source elided>
            _ray_ix = ray_indices[:ray_pointer, 1]
            for each_y, each_x in zip(_ray_iy, _ray_ix):
            ^
```

This is due to Numba trying to figure out the type of `swt_matrix` in `swt_strokes`, but it can be either case of the if (Numba doesn't check the actual value provided to `include_edges_in_swt` before it determines the types)

```
    # ...
    if include_edges_in_swt:
        swt_matrix = edged_image.copy()
    else:
        swt_matrix = np.zeros(shape=edged_image.shape, dtype=np.int32)
    # ...
```